### PR TITLE
Dashboard - Danger Zone Confirmations

### DIFF
--- a/packages/dashboard/src/routes/app/instances/[instanceId]/Danger/RenameInstance.svelte
+++ b/packages/dashboard/src/routes/app/instances/[instanceId]/Danger/RenameInstance.svelte
@@ -4,6 +4,7 @@
   import { DOCS_URL } from '$src/env'
   import { client } from '$src/pocketbase'
   import { instance } from '../store'
+  import { slide } from 'svelte/transition'
 
   const { renameInstance } = client()
 
@@ -17,6 +18,9 @@
 
   // Controls the disabled state of the button
   let isButtonDisabled = false
+
+  // Controls visibility of an error message
+  let errorMessage = ''
 
   // TODO: What are the limits for this?
   const onRename = (e: Event) => {
@@ -35,12 +39,14 @@
 
     // If they select yes, then update the version in pocketbase
     if (confirmVersionChange) {
-      // TODO: Set up error handling for when the name is wrong
-      // TODO: Do validations like trim and removing numbers
       renameInstance({
         instanceId: id,
         subdomain: instanceNameValidation,
-      }).then(() => 'saved')
+      })
+        .then(() => 'saved')
+        .catch((error) => {
+          errorMessage = error.message
+        })
     }
 
     // Set the button back to normal
@@ -59,6 +65,13 @@
     > by the old instance name. You also may not be able to change it back if someone
     else choose it.
   </p>
+
+  {#if errorMessage}
+    <div in:slide class="alert alert-error mb-4">
+      <i class="fa-regular fa-circle-exclamation"></i>
+      {errorMessage}
+    </div>
+  {/if}
 
   <form
     class="flex rename-instance-form-container-query gap-4"

--- a/packages/dashboard/src/routes/app/instances/[instanceId]/Danger/RenameInstance.svelte
+++ b/packages/dashboard/src/routes/app/instances/[instanceId]/Danger/RenameInstance.svelte
@@ -25,11 +25,23 @@
     // Disable the button to prevent double submissions
     isButtonDisabled = true
 
-    // TODO: Set up error handling for when the name is wrong
-    // TODO: Do validations like trim and removing numbers
-    renameInstance({ instanceId: id, subdomain: formSubdomain }).then(
-      () => 'saved',
+    // Remove extra whitespace, and numbers from the subdomain
+    const instanceNameValidation = formSubdomain.trim().replace(/[0-9]/g, '')
+
+    // Prompt the user to confirm the version change
+    const confirmVersionChange = confirm(
+      `Are you sure you want to rename your instance to ${instanceNameValidation}?`,
     )
+
+    // If they select yes, then update the version in pocketbase
+    if (confirmVersionChange) {
+      // TODO: Set up error handling for when the name is wrong
+      // TODO: Do validations like trim and removing numbers
+      renameInstance({
+        instanceId: id,
+        subdomain: instanceNameValidation,
+      }).then(() => 'saved')
+    }
 
     // Set the button back to normal
     isButtonDisabled = false
@@ -53,10 +65,13 @@
     on:submit={onRename}
   >
     <input
+      title="Only letters and dashes are allowed"
+      required
       type="text"
       bind:value={formSubdomain}
       class="input input-bordered w-full"
     />
+
     <button type="submit" class="btn btn-error" disabled={isButtonDisabled}
       >Rename Instance</button
     >

--- a/packages/dashboard/src/routes/app/instances/[instanceId]/Danger/VersionChange.svelte
+++ b/packages/dashboard/src/routes/app/instances/[instanceId]/Danger/VersionChange.svelte
@@ -19,12 +19,23 @@
     // Disable the button to prevent double submissions
     isButtonDisabled = true
 
-    // Save to the database
-    client()
-      .saveVersion({ instanceId: id, version: version })
-      .then(() => {
-        return 'saved'
-      })
+    // Prompt the user to confirm the version change
+    const confirmVersionChange = confirm(
+      `Are you sure you want to change the version to ${version}?`,
+    )
+
+    // If they select yes, then update the version in pocketbase
+    if (confirmVersionChange) {
+      // Save to the database
+      client()
+        .saveVersion({ instanceId: id, version: version })
+        .then(() => {
+          return 'saved'
+        })
+    } else {
+      // If they hit cancel, reset the version number back to what it was initially
+      version = $instance.version
+    }
 
     // Set the button back to normal
     isButtonDisabled = false
@@ -51,6 +62,7 @@
     on:submit={handleSave}
   >
     <input
+      required
       type="text"
       bind:value={version}
       class="input input-bordered w-full"


### PR DESCRIPTION
Added the native browser `confirm()` dialog to the Danger Zone forms. This utilizes the built in browser feature to confirm the form. It also uses the mobile OS dialog too so it has a more "native" feel.

🧼 Added string cleaning to the instance creation widget. It filteres out numbers and trims white space

⚠️ Added in error messaging for instance renaming if something goes wrong

🪲 Fixed a bug where the version number wasn't updating when you navigated between instances

❓ Note: I wasn't able to get an error to show up for the version number. Does it let you add in anything you want?

![image](https://github.com/pockethost/pockethost/assets/66521220/3018260f-5e36-411c-ae7b-dac188656d26)

![image](https://github.com/pockethost/pockethost/assets/66521220/cbcc9d99-0383-492a-b5e6-0ffc3b6692ab)

![image](https://github.com/pockethost/pockethost/assets/66521220/d0a89a60-6956-430b-9066-4ae0e2fbd832)
