### PR TITLE
Added table names on desktop to Pricing Table

### DIFF
--- a/frontends/dashboard/src/components/Navbar.svelte
+++ b/frontends/dashboard/src/components/Navbar.svelte
@@ -59,9 +59,7 @@
   </MediaQuery>
 
   <div class="flex flex-col gap-2 mb-auto h-full">
-    <div class="mt-16">
-      <SubscriptionStatus {handleClick} />
-    </div>
+    <SubscriptionStatus {handleClick} />
 
     <a on:click={handleClick} href="/" class={linkClasses}>
       <i

--- a/frontends/dashboard/src/components/tables/pricing-table/PricingTable.svelte
+++ b/frontends/dashboard/src/components/tables/pricing-table/PricingTable.svelte
@@ -51,16 +51,14 @@
                       <th scope="col">
                         <span class="sr-only">Feature</span>
                       </th>
-                      <th scope="col">
-                        <span class="sr-only">Starter tier</span>
+                      <th scope="col" class="text-center">
+                        {PLAN_NAMES[SubscriptionType.Free]}
                       </th>
-                      <th scope="col">
-                        <span class="sr-only">Scale tier</span>
+                      <th scope="col" class="text-center">
+                        {PLAN_NAMES[SubscriptionType.Premium]}
                       </th>
-                      <th scope="col">
-                        <span class="sr-only"
-                          >{PLAN_NAMES[SubscriptionType.Lifetime]} tier</span
-                        >
+                      <th scope="col" class="text-center">
+                        {PLAN_NAMES[SubscriptionType.Lifetime]}
                       </th>
                     </tr>
                   </thead>


### PR DESCRIPTION
- Removed spacing from the sidebar Account Type card
- Added table headers to the desktop Pricing Plan
![image](https://github.com/pockethost/pockethost/assets/66521220/13511386-ee9d-4078-963f-4f8b9ef8fc27)
