### PR TITLE
Bug Fix: Instance Name In Title Not Updating Bug

### DIFF
--- a/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
+++ b/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
@@ -22,6 +22,10 @@
   $: ({ status, version, id } = $instance || {})
 </script>
 
+<svelte:head>
+  <title>{$instance.subdomain} overview - PocketHost</title>
+</svelte:head>
+
 {#if isReady}
   <div
     class="flex md:flex-row flex-col items-center justify-between mb-6 gap-4"

--- a/frontends/dashboard/src/routes/app/instances/[instanceId]/+page.svelte
+++ b/frontends/dashboard/src/routes/app/instances/[instanceId]/+page.svelte
@@ -10,10 +10,6 @@
   const { subdomain } = $instance
 </script>
 
-<svelte:head>
-  <title>{subdomain} overview - PocketHost</title>
-</svelte:head>
-
 <div class="grid lg:grid-cols-2 grid-cols-1 gap-4 mb-4">
   <Code />
   <Ftp />


### PR DESCRIPTION
Moved title meta from the page to the layout to address the bug of the instance name in the window title not updating.