### PR TITLE
Title Bug Fix When Refreshing

### DIFF
--- a/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
+++ b/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <svelte:head>
-  <title>{isReady ? $instance.subdomain : Instance} overview - PocketHost</title>
+  <title>{isReady ? $instance.subdomain : "Instance"} overview - PocketHost</title>
 </svelte:head>
 
 {#if isReady}

--- a/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
+++ b/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
@@ -22,6 +22,10 @@
   $: ({ status, version, id } = $instance || {})
 </script>
 
+<svelte:head>
+  <title>{$instance.subdomain} overview - PocketHost</title>
+</svelte:head>
+
 {#if isReady}
   <div
     class="flex md:flex-row flex-col items-center justify-between mb-6 gap-4"

--- a/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
+++ b/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
@@ -5,7 +5,6 @@
   import { INSTANCE_ADMIN_URL } from '$src/env'
   import { globalInstancesStore } from '$util/stores'
   import { instance } from './store'
-  import {onMount} from 'svelte'
 
   let isReady = false
   $: {
@@ -18,27 +17,11 @@
     isReady = !!_instance
   }
 
-  let title = ''
-  let titleSetInt
-
-  onMount(() => {
-    titleSetInt = setInterval(() => {
-      if (isReady) {
-        title = $instance.subdomain
-      }
-    }, 10)
-  })
-
-  $: if (isReady && title !== '') {
-    clearInterval(titleSetInt)
-    title = $instance.subdomain
-  }
-
   $: ({ status, version, id } = $instance || {})
 </script>
 
 <svelte:head>
-  <title>{title} overview - PocketHost</title>
+  <title>{isReady ? $instance.subdomain : Instance} overview - PocketHost</title>
 </svelte:head>
 
 {#if isReady}

--- a/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
+++ b/frontends/dashboard/src/routes/app/instances/[instanceId]/+layout.svelte
@@ -5,6 +5,7 @@
   import { INSTANCE_ADMIN_URL } from '$src/env'
   import { globalInstancesStore } from '$util/stores'
   import { instance } from './store'
+  import {onMount} from 'svelte'
 
   let isReady = false
   $: {
@@ -17,13 +18,27 @@
     isReady = !!_instance
   }
 
-  console.log($page.url)
+  let title = ''
+  let titleSetInt
+
+  onMount(() => {
+    titleSetInt = setInterval(() => {
+      if (isReady) {
+        title = $instance.subdomain
+      }
+    }, 10)
+  })
+
+  $: if (isReady && title !== '') {
+    clearInterval(titleSetInt)
+    title = $instance.subdomain
+  }
 
   $: ({ status, version, id } = $instance || {})
 </script>
 
 <svelte:head>
-  <title>{$instance.subdomain} overview - PocketHost</title>
+  <title>{title} overview - PocketHost</title>
 </svelte:head>
 
 {#if isReady}

--- a/frontends/dashboard/src/routes/app/instances/[instanceId]/+page.svelte
+++ b/frontends/dashboard/src/routes/app/instances/[instanceId]/+page.svelte
@@ -10,10 +10,6 @@
   const { subdomain } = $instance
 </script>
 
-<svelte:head>
-  <title>{subdomain} overview - PocketHost</title>
-</svelte:head>
-
 <div class="grid lg:grid-cols-2 grid-cols-1 gap-4 mb-4">
   <Code />
   <Ftp />


### PR DESCRIPTION
Fixes a bug caused by the new dynamic title, when it tried to set the title before the global instance stores were fully initialized, causing an error. Fixed by implementing the first attempt after the layout has been mounted, and is subsequently checked and set with an interval that is canceled once the title has been set. Setting the title is then passed off to a reactive declaration.