### PR TITLE
fix: validate lemonsqueezy webhook callback

### DIFF
--- a/src/mothership-app/pb_hooks/src/ls.pb.js
+++ b/src/mothership-app/pb_hooks/src/ls.pb.js
@@ -13,6 +13,16 @@ routerAdd('POST', '/api/ls', (c) => {
   const data = JSON.parse(raw)
   log(`payload`, JSON.stringify(data, null, 2))
 
+  const body_hash = $security.hs256(raw, secret)
+  log(`Body hash`, body_hash)
+
+  const xsignature_header = c.request().header.get('X-Signature')
+  log(`Signature`, xsignature_header)
+
+  if (xsignature_header == undefined || !$security.equal(body_hash, xsignature_header)) {
+    return c.json(401, { error: 'Invalid signature' })
+  }
+
   /** @type {WebHook} */
   let {
     meta: {


### PR DESCRIPTION
Validates LemonSqueezy webhook callbacks for payments using the X-Signature header that is sent with every LS request.
It hashes the body content using the value in the "LS_WEBHOOK_SECRET" env variable (I belive you set it to the LS signature) and compars the hash with the value in the X-Signature header.

It is described here [LemonSqueezy Webhooks](https://docs.lemonsqueezy.com/help/webhooks#signing-requests).
Since I can't test it, please make sure it is actually working.