### PR TITLE
Added LS Unsigned billing URL to allow subscribers to manage their subscription/account

### DIFF
--- a/packages/dashboard/src/routes/(app)/account/+page.svelte
+++ b/packages/dashboard/src/routes/(app)/account/+page.svelte
@@ -30,6 +30,6 @@
   </div>
 
   <div>
-    <a class="m-4 btn btn-neutral" href="/support"> Manage Membership </a>
+    <a class="m-4 btn btn-neutral" href="https://store.pockethost.io/billing" target="_blank"> Manage Membership </a>
   </div>
 </div>


### PR DESCRIPTION
Documentation: https://docs.lemonsqueezy.com/guides/developer-guide/customer-portal


> Unsigned URL
If you don’t want to make an API call when a customer clicks through to the Customer Portal you can use the unsigned URL: https://[STORE].lemonsqueezy.com/billing

> if your customer is not already logged into their Lemon Squeezy account, they will see a form to [log in via an email magic link](https://docs.lemonsqueezy.com/help/online-store/my-orders#logging-in) like My Orders. 
