### PR TITLE
feat: Add subdomain text truncation to prevent UI overlap

### DIFF
--- a/packages/dashboard/src/routes/(app)/dashboard/InstanceList.svelte
+++ b/packages/dashboard/src/routes/(app)/dashboard/InstanceList.svelte
@@ -31,7 +31,7 @@
     <div class="card-body w-full">
       <div class="card-title">
         <div class="flex justify-between items-center w-full">
-          <span>{instance.subdomain}</span>
+          <span>{instance.subdomain.length > 15 ? instance.subdomain.slice(0, 15) + '...' : instance.subdomain}</span>
           <input
             type="checkbox"
             class="toggle {instance.power


### PR DESCRIPTION
Implements text truncation for long subdomain names in the instance list view to improve the UI layout and prevent text overlap with the toggle button.

Changes:
- Added text truncation logic for subdomains longer than 15 characters
- Appends ellipsis (...) to indicate truncated text
- Improves readability and prevents UI layout issues

Before this change, long subdomain names could overlap with the power toggle button, causing poor user experience. Now, any subdomain longer than 15 characters will be truncated with an ellipsis, maintaining a clean and consistent layout while still indicating there's more text available.