### PR TITLE
Avoid serving pockethost Google Analytics cookies to subdomains

### DIFF
--- a/packages/dashboard/src/routes/+layout.svelte
+++ b/packages/dashboard/src/routes/+layout.svelte
@@ -110,6 +110,9 @@
     }
     gtag('js', new Date())
 
-    gtag('config', 'G-5Q6CM5HPCX')
+    gtag('config', 'G-5Q6CM5HPCX', {
+      // Avoid sending the cookie to subdomains of pockethost.io.
+      'cookie_domain': 'none'
+    })
   </script>
 </div>


### PR DESCRIPTION
This configures Google Analytics to not set a domain on its cookie (https://developers.google.com/tag-platform/security/guides/customize-cookies)

The default behavior is to set the domain to the root domain, allowing tracking on all subdomains.

Not setting the domain limits the cookie to just pockethost.io.