### PR TITLE
Fix missing auth token refresh in user subscription handler

### DIFF
--- a/packages/dashboard/src/util/stores.ts
+++ b/packages/dashboard/src/util/stores.ts
@@ -171,9 +171,8 @@ const tryUserSubscribe = (() => {
     console.log('Subscribing to user', id)
     client()
       .client.collection('users')
-      .subscribe<UserFields>(id, (data) => {
-        console.log('User subscribed update', data)
-        client().client.collection('users').authRefresh().catch(console.error)
+      .subscribe<UserFields>(id, () => {
+        console.log('User subscribed update')
       })
       .then((u) => {
         console.log('Subscribed to user', id)


### PR DESCRIPTION
The auth token refresh was being called unconditionally in the user subscription callback, even if the subscription was for a different user ID. This caused unnecessary server load and potential race conditions. The fix moves the token refresh logic outside the subscription callback, ensuring it only runs when the store changes.