### PR TITLE
fixing homepage button not using white text

### DIFF
--- a/packages/dashboard/src/routes/(static)/Splash/PrimaryButton.svelte
+++ b/packages/dashboard/src/routes/(static)/Splash/PrimaryButton.svelte
@@ -13,7 +13,7 @@
 
   <a
     href={url}
-    class={`relative ${className} inline-flex gap-4 items-center bg-primary justify-center px-8 py-3 text-md font-medium hover:bg-light text-white transition-all duration-200 font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900`}
+    class={`relative ${className} inline-flex gap-4 items-center bg-primary justify-center px-8 py-3 text-md font-medium hover:bg-light !text-white transition-all duration-200 font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900`}
     {target}
     role="button"
   >


### PR DESCRIPTION
Fixing this:  
<img width="722" height="377" alt="image" src="https://github.com/user-attachments/assets/afbbd8ab-0e60-4276-a0c4-85c31e3fac74" />
 